### PR TITLE
fix: resolve TypeError in is_telomere_read with --consecutive flag (-con)

### DIFF
--- a/src/telomerehunter2/filter_telomere_reads.py
+++ b/src/telomerehunter2/filter_telomere_reads.py
@@ -46,21 +46,22 @@ def is_telomere_read(
         sequence,
         repeat_threshold_calc,
 ):
-    # Important filtering logic: check if read has the specified amount of patterns, else skip
     if consecutive_flag:
-        # Check if consecutive repeats of forward or reverse patterns in the sequence meet the repeat threshold
-        return patterns_regex_forward.search(
-            f"({patterns_regex_forward.pattern}){{{repeat_threshold_calc},}}", sequence
-        ) or patterns_regex_reverse.search(
-            f"({patterns_regex_reverse.pattern}){{{repeat_threshold_calc},}}", sequence
+        consecutive_pattern_fwd = re.compile(
+            f"(?:{patterns_regex_forward.pattern}){{{repeat_threshold_calc},}}"
+        )
+        consecutive_pattern_rev = re.compile(
+            f"(?:{patterns_regex_reverse.pattern}){{{repeat_threshold_calc},}}"
+        )
+        return bool(
+            consecutive_pattern_fwd.search(sequence)
+            or consecutive_pattern_rev.search(sequence)
         )
     else:
-        # Check if the count of forward or reverse patterns in the sequence meets the repeat threshold
         return (
-                len(patterns_regex_forward.findall(sequence)) >= repeat_threshold_calc
-                or len(patterns_regex_reverse.findall(sequence)) >= repeat_threshold_calc
+            len(patterns_regex_forward.findall(sequence)) >= repeat_threshold_calc
+            or len(patterns_regex_reverse.findall(sequence)) >= repeat_threshold_calc
         )
-
 
 def initialize_chromosome_and_band_data(bamfile, band_file=None):
     """Initialize chromosome and band data structures for filtering.


### PR DESCRIPTION
When running telomerehunter2 with the `-con` flag, the following error is raised repeatedly for every unmapped read:

TypeError: 'str' object cannot be interpreted as an integer

In `is_telomere_read`, the consecutive branch calls:
    patterns_regex_forward.search(new_pattern_string, sequence)

On a compiled regex object, `.search(string, pos)` interprets the second argument as an integer start position, not a search string.

Also in tests/test_telomerehunter2.py, if -con flag is added to the command, both tests fail.

FIX : Compile the consecutive pattern at call time and call `.search(sequence)`: re.compile(f"(?:{...}){{{n},}}").search(sequence)

Tested on real BAM files, using Python 3.12, using -ibt -ibc -p -o -pl -pno -frt -b and -con flags.
