### PR TITLE
fix: pass missing args to compile_patterns() in parallel_filter_telomere_reads

### DIFF
--- a/src/telomerehunter2/filter_telomere_reads.py
+++ b/src/telomerehunter2/filter_telomere_reads.py
@@ -506,7 +506,7 @@ def parallel_filter_telomere_reads(
             lengths = bamfile.lengths
 
         # Compile regex patterns
-        patterns_regex_forward, patterns_regex_reverse = compile_patterns(repeats)
+        patterns_regex_forward, patterns_regex_reverse = compile_patterns(repeats, consecutive_flag, repeat_threshold_calc)
 
         results = []
         max_position = 0


### PR DESCRIPTION
After the refactor in compile_patterns() (introduced as a follow-up to #19), 
the call site in parallel_filter_telomere_reads() was not updated to pass the two 
new required arguments, causing a TypeError on every invocation regardless of whether 
-con is used.

Fix: pass consecutive_flag and repeat_threshold_calc to compile_patterns().

Tested on real BAM files with and without -con flag.